### PR TITLE
Improve simulation accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ NB: it can also be added as a custom repository if you have an issue with above 
 
 * Set the group of entities to be used in the simulation. It can be a group of lights, switches, covers, light groups, media_player or of any component that can be turned on and off with the service `homeassistant.turn_on` and `homeassistant.turn_off`. You can also setup several entities, separated with ','
 * Set the number of days of history the simulation will use (the delta)
-* Set the scan interval in seconds to check whether the simulation has ended. A small number here will reduce the amount of time for the simulation to halt when requested, at the expense of more computing. Default is 30 seconds.
+* Set the poll interval in seconds that determines how quickly the simulation notices that it has been requested to stop. Default is 30 seconds. Warning, the smaller the number you choose, the more computing process the component will take.
 * After the simulation, choose to restore the states as they were before the start of ths simulation
 * You can choose to randomize the activation/deactivation of your entities. '0' to disable this behaviour, or a period in seconds for the maximum of seconds the random switching will be done. This random period is added (or substracted) from the time the entity was actually switched on or off in your historical data.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ NB: it can also be added as a custom repository if you have an issue with above 
 
 * Set the group of entities to be used in the simulation. It can be a group of lights, switches, covers, light groups, media_player or of any component that can be turned on and off with the service `homeassistant.turn_on` and `homeassistant.turn_off`. You can also setup several entities, separated with ','
 * Set the number of days of history the simulation will use (the delta)
-* Set the number for a scan interval used to switch entities in seconds. Default is 30 seconds. Warning, the smaller the number you choose, the more computing process the component will take.
+* Set the scan interval in seconds to check whether the simulation has ended. A small number here will reduce the amount of time for the simulation to halt when requested, at the expense of more computing. Default is 30 seconds.
 * After the simulation, choose to restore the states as they were before the start of ths simulation
 * You can choose to randomize the activation/deactivation of your entities. '0' to disable this behaviour, or a period in seconds for the maximum of seconds the random switching will be done. This random period is added (or substracted) from the time the entity was actually switched on or off in your historical data.
 

--- a/custom_components/presence_simulation/strings.json
+++ b/custom_components/presence_simulation/strings.json
@@ -6,7 +6,7 @@
                 "data": {
                     "entities": "Entity or group of entities",
                     "delta": "Delta (in days)",
-                    "interval": "Refresh interval (in seconds)",
+                    "interval": "Poll interval (in seconds)",
                     "restore": "Restore state after simulation"
                 }
             }
@@ -19,7 +19,7 @@
                 "data": {
                     "entities": "Entity or group of entities",
                     "delta": "Delta (in days)",
-                    "interval": "Refresh interval (in seconds)",
+                    "interval": "Poll interval (in seconds)",
                     "restore": "Restore state after simulation"
                 }
             }


### PR DESCRIPTION
Fixes the sleep intervals so a task does not oversleep. It used to be that a task slept a fixed "interval" and so could miss the deadline for the next state change.

Also, skips jitter when setting the initial state in the simulation window.

With this change, the "interval" config parameter only affects how long it takes the simulation tasks to notice when the simulation is no longer running. "interval" no longer affects how accurate the simulation is in the timing of replayed events.
