### PR TITLE
Improve simulation state recovery on HA restart

### DIFF
--- a/custom_components/presence_simulation/switch.py
+++ b/custom_components/presence_simulation/switch.py
@@ -29,35 +29,31 @@ class PresenceSimulationSwitch(SwitchEntity):
     instances = 0
 
     def __init__(self, hass):
-        self.internal_turn_off()
         self.hass = hass
         self.attr={}
         self.attr["friendly_name"] = "Presence Simulation Toggle"
+        self._attr_name = "Presence Simulation"
+        # As HA is starting, we don't know the running state of the simulation
+        # until restore_state() runs.
+        self._attr_available = False
+        # State is represented by _attr_is_on, which is initialzied
+        # to None by homeassistant/helpers/entity.py:ToggleEntity.
+        # State will be initialized when restore_state() runs.
         self._next_events = []
         PresenceSimulationSwitch.instances += 1
 
-    @property
-    def name(self):
-        return "Presence Simulation"
-
-    @property
-    def is_on(self):
-        """Return True if the state is on"""
-        return self._state == "on"
-
-    @property
-    def state(self):
-        """Return the state of the switch"""
-        return self._state
-
     def internal_turn_on(self, **kwargs):
         """Turn on the presence simulation flag. Does not launch the simulation, this is for the calls from the services, to avoid a loop"""
-        self._state = "on"
+        self._attr_available = True
+        self._attr_is_on = True
+        self.async_write_ha_state()
 
     def internal_turn_off(self, **kwargs):
         """Turn off the presence simulation flag. Does not launch the stop simulation service, this is for the calls from the services, to avoid a loop"""
-        self._state = "off"
+        self._attr_available = True
+        self._attr_is_on = False
         self._next_events = []
+        self.async_write_ha_state()
 
     def turn_on(self, **kwargs):
         """Turn on the presence simulation"""


### PR DESCRIPTION
The presence simulation switch did not seem to reliably update persistent state, which meant that manually operation of the switch did not seem to persist across HA restarts. This diff does a few things:

- Make `switch.internal_turn_[on, off]` call `self.async_write_ha_state()` to actively inform HA of state changes.
- Collect together calls to set the attributes of the switch before turning on, so the attributes are persisted as well with the call to `self.async_write_ha_state()`
- Simplify switch to use the `is_on`, `state` and `name` functionality inherited from ToggleEntity rather than duplicating it.
- Set inherited switch attribute `_attr_available` initially to False until `restore_state` runs and determines the the prior running state of the simulation. This mostly affects the lovelace UI representation of the switch.
- When restoring switch state, tolerate missing `entity_id` attribute in the database. In this case it logs an error and abandons any previous simulation that may have been running.
- Remove unused local variable `running`
