### PR TITLE
Update how events are removed from list.

### DIFF
--- a/custom_components/presence_simulation/switch.py
+++ b/custom_components/presence_simulation/switch.py
@@ -120,11 +120,7 @@ class PresenceSimulationSwitch(SwitchEntity):
 
     async def async_remove_event(self, entity_id):
         """Remove the next event of an entity"""
-        i=0
-        for e in self._next_events:
-            if e[1] == entity_id:
-                del self._next_events[i]
-            i += 1
+        self._next_events = [e for e in self._next_events if e[1] != entity_id]
 
     async def set_start_datetime(self, start_datetime):
         self.attr["simulation_start"] = start_datetime


### PR DESCRIPTION
Currently, when events are removed from the `_next_events` list it uses a for loop and del. This modifies the list during iteration and results in the possibility of missing an event to be deleted. In the similar implementation below, we see that the first and last `3` are removed but the second one in the run is not.

```python
In [1]: a = [1, 2, 3, 3, 4, 6, 3]
In [2]: def remove(x, l):
   ...:     i=0
   ...:     for e in l:
   ...:         if e == x:
   ...:             del l[i]
   ...:         i += 1
In [3]: remove(3, a)
In [4]: a
Out[4]: [1, 2, 3, 4, 6]
```

This PR updates the removal method by using a list comprehension and `if` to filter out events based on entity_id.

Note: The comment and the implementation seem to imply different things. The comment says to delete the _next_ event for an entity while the implementation deletes _all_ events (ignoring the bug above) for an entity. If the semantics of the comment are correct this PR should not be merged and instead a `break` should be added after the `del` statement.