### PR TITLE
Default unavailable as off

### DIFF
--- a/custom_components/presence_simulation/switch.py
+++ b/custom_components/presence_simulation/switch.py
@@ -58,7 +58,7 @@ class PresenceSimulationSwitch(SwitchEntity,RestoreEntity):
         self._interval = int(config.data["interval"])
         self._delta = config.data["delta"]
         self._restore = config.data["restore"]
-        self._unavailable_as_off = config.data["unavailable_as_off"]
+        self._unavailable_as_off = config.data.get("unavailable_as_off", False)
         self.reset_default_values()
         _LOGGER.debug("entities %s", config.data["entities"])
 


### PR DESCRIPTION
Using version 4.6 I'm getting this error on a HA (2024.4.4) restart.

The new unavailable_as_off has not been defaulted and as I didn't go into the integration config and save it can't find the key.

```
Error while setting up presence_simulation platform for switch
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 356, in _async_setup_platform
    await asyncio.shield(awaitable)
  File "/config/custom_components/presence_simulation/switch.py", line 28, in async_setup_entry
    async_add_devices([PresenceSimulationSwitch(hass, config_entry)], True)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/presence_simulation/switch.py", line 34, in __init__
    self.update_config(config)
  File "/config/custom_components/presence_simulation/switch.py", line 61, in update_config
    self._unavailable_as_off = config.data["unavailable_as_off"]
                               ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'unavailable_as_off'
```