### PR TITLE
Update switch.py - fix typo in 4.13 release

### DIFF
--- a/custom_components/presence_simulation/switch.py
+++ b/custom_components/presence_simulation/switch.py
@@ -63,7 +63,7 @@ class PresenceSimulationSwitch(SwitchEntity,RestoreEntity):
         if "labels" in conf:
             self._labels = conf["labels"]
         else:
-            seld._labels = []
+            self._labels = []
         self._random = int(conf["random"])
         self._interval = int(conf["interval"])
         self._delta = conf["delta"]


### PR DESCRIPTION
Fixed typo "seld" to "self" that caused switch for Presence Simulation to not respond.