### PR TITLE
HA 2026.1: Use light attribute color_temp_kelvin instead of color_temp

### DIFF
--- a/custom_components/presence_simulation/__init__.py
+++ b/custom_components/presence_simulation/__init__.py
@@ -433,6 +433,9 @@ async def async_setup_entry(hass, entry):
                 if color_mode != "color_temp":
                     # Attribute color_mode will be xy, hs, rgb...
                     color_mode = color_mode+"_color"
+                else:
+                    # Attribute color_mode will be in kelvin
+                    color_mode = "color_temp_kelvin"
                 if color_mode in state.attributes and state.attributes[color_mode] is not None:
                     service_data[color_mode] = state.attributes[color_mode]
             if state.state == "on" or state.state == "off" or (state.state == "unavailable" and unavailable_as_off):


### PR DESCRIPTION
I have been [working on an integration to store database history of light attributes](https://github.com/ronaldheft/ha-light-reilluminator) like `color_temp` and `brightness` (restoring behavior prior to HA 2024.8 #139 #194). While testing my integration with presence_simulation, I discovered presence_simulation sets light color temperature using the attribute `color_temp`, [which is deprecated](https://developers.home-assistant.io/blog/2024/12/14/kelvin-preferred-color-temperature-unit/) and [will be removed in HA 2026.1](https://github.com/home-assistant/core/blob/4e8d68a2efca4e98019453ab5c5491a36f3ca222/homeassistant/components/light/__init__.py#L204).

This PR changes the referenced light attribute to `color_temp_kelvin`. This change is backward compatible all the way to HA 2022.11, when Home Assistant added the attribute. [As noted in the deprecation announcement](https://www.home-assistant.io/blog/2022/11/02/release-202211/#color-temperatures-in-kelvin), this change only applies to the `light.turn_on` service; Home Assistant is still handling kelvin <> mired internally. Therefore, this change will also work with all light integrations and is safe to release prior to 2026.1.