### PR TITLE
doc: How to simulate light attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Supported entities domains:
 # Pre-requisit
 The `history` integration must be activated - [which it is by default](https://www.home-assistant.io/integrations/history/). The period kept in the DB should be bigger than the delta used in the simulation. The default number of days kept is 10 and this [can be configured](https://www.home-assistant.io/integrations/recorder/) with the `recorder` integration.
 
+## Light Attributes (Optional)
+
+To simulate light brightness changes and color temperature changes, attribute data must be stored in the [recorder](https://www.home-assistant.io/integrations/recorder/) database. Without these attributes, presence_simulation will only simulate the action of turning lights on and off.
+
+The Home Assistant component [Light Reilluminator](https://github.com/ronaldheft/ha-light-reilluminator) can be installed alongside presence_simulation to store light attributes. This component will enable presence_simulation to turn lights on at their previous set brightness and color temperature values and update their values as they change.
+
 # Tutorials
 - Smart Home Junkie's English tutorial: https://youtu.be/OTQu3BMr3EU
 - Tristan's Smartes Heim's German tutorial: https://youtu.be/5vCp3iKZb4Q


### PR DESCRIPTION
I released a new component called [HA Light Reilluminator](https://github.com/ronaldheft/ha-light-reilluminator) that pairs well with presence_simulation by recording the history of light attributes, such as brightness or color temperature, in your recorder database.

Since this is likely of interest to users of presence_simulation, I added a section to the documentation covering why light attributes are not simulated by default and how HA Light Reilluminator can be used to address this use case. No hard feelings if you'd like to keep this out of the docs or would prefer different phrasing in the documentation. 🙂