### PR TITLE
Dedupe expanded entity list to prevent parallel races

### DIFF
--- a/custom_components/presence_simulation/services.py
+++ b/custom_components/presence_simulation/services.py
@@ -115,6 +115,12 @@ class PresenceSimulationServices:
             return
 
         expanded_entities += expanded_labels
+        # Dedup while preserving order: an entity can be referenced multiple times
+        # (direct + via group + via label). Without dedup, _simulate_single_entity
+        # runs in parallel for the same entity_id and fires turn_on/off in a race,
+        # causing the flicker reported in #174, #193 and the stuck-on state in #179.
+        expanded_entities = list(dict.fromkeys(expanded_entities))
+        _LOGGER.debug("Deduplicated entities: %s", expanded_entities)
 
         if len(expanded_entities) == 0:
             _LOGGER.error("Error during identifying entities, no valid entities has been found")


### PR DESCRIPTION
## Problem

When the service is called with a set of entities where the same entity is referenced more than once (a direct entity, plus a group that contains it, plus a label that also applies to it), `_simulate_single_entity` is spawned multiple times for the same `entity_id`. The parallel tasks then fire `turn_on` / `turn_off` for the same entity in a race and the real state ends up wrong — the light flickers, or stays on after the simulation window ends.

## Fix

Dedupe `expanded_entities` before kicking off the per-entity tasks. `dict.fromkeys` keeps insertion order and drops later duplicates in a single pass.

Six lines, no behavior change for the unique-entity case.

## Closes

- Fixes #174 (flicker)
- Fixes #193 (second flicker report, same root cause)
- Fixes #179 (entity stuck on after simulation ends)

## Testing

Verified locally with a config that mixes direct entities, a group and a label pointing at the same light. Before the patch the light was flickering and occasionally staying on; after the patch it toggles cleanly.