### PR TITLE
Fix config flow error for new initial set-up of integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Supported entities domains:
 - `input_select`
 - All domains for which entities have status `on` or `off` that can be turned on/off with service `homeassistant.turn_on` and `homeassistant.turn_off` (`automation`, `switch`, `group`...).
 
-# Pre-requisit
+# Pre-requisites
 The `history` integration must be activated - [which it is by default](https://www.home-assistant.io/integrations/history/). The period kept in the DB should be bigger than the delta used in the simulation. The default number of days kept is 10 and this [can be configured](https://www.home-assistant.io/integrations/recorder/) with the `recorder` integration.
 
 ## Light Attributes (Optional)

--- a/custom_components/presence_simulation/config_flow.py
+++ b/custom_components/presence_simulation/config_flow.py
@@ -41,9 +41,9 @@ class PresenceSimulationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required("delta", default=DEFAULT_DELTA): DELTA_VALIDATOR,
             vol.Required("interval", default=DEFAULT_INTERVAL): INTERVAL_VALIDATOR,
             vol.Required("restore", default=False): bool,
-            vol.Required("random", default=0): RANDOM_validator,
+            vol.Required("random", default=0): RANDOM_VALIDATOR,
             vol.Required("unavailable_as_off", default=False): bool,
-            vol.Required("brightness", default=0): BRIGHTNESS_validator,
+            vol.Required("brightness", default=0): BRIGHTNESS_VALIDATOR,
         }
         if not info:
             return self.async_show_form(


### PR DESCRIPTION
Case on _VALIDATOR fixed in two places in config_flow.py. This fixes error "config flow could not be loaded: 500 Internal Server Error Server got itself in trouble".

Minor typo fixed in README.md.