### PR TITLE
Add a fixed history window for vacation simulation

### DIFF
--- a/blueprints/automation/presence_simulation/extended_away.yaml
+++ b/blueprints/automation/presence_simulation/extended_away.yaml
@@ -1,0 +1,66 @@
+blueprint:
+  name: Presence Simulation - extended absence
+  description: >-
+    Starts Presence Simulation after an entity has been on for the configured
+    time. The source history ends at the moment the absence began, so activity
+    recorded while the house is empty is never replayed. Stops on return.
+  domain: automation
+  input:
+    away_entity:
+      name: Afwezigheidsentiteit
+      description: An input_boolean or binary_sensor that is on while everyone is away.
+      selector:
+        entity:
+          filter:
+            - domain:
+                - binary_sensor
+                - input_boolean
+    absence_delay:
+      name: Startvertraging
+      description: Start the simulation only after this many hours of absence.
+      default: 24
+      selector:
+        number:
+          min: 0
+          max: 168
+          step: 1
+          unit_of_measurement: hours
+          mode: box
+    simulation_switch:
+      name: Presence Simulation-schakelaar
+      selector:
+        entity:
+          filter:
+            - domain: switch
+
+mode: single
+
+triggers:
+  - trigger: state
+    entity_id: !input away_entity
+    to: "on"
+    for:
+      hours: !input absence_delay
+    id: away
+  - trigger: state
+    entity_id: !input away_entity
+    to: "off"
+    id: home
+
+actions:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id: away
+        sequence:
+          - action: presence_simulation.start
+            data:
+              switch_id: !input simulation_switch
+              history_end: "{{ trigger.to_state.last_changed.isoformat() }}"
+      - conditions:
+          - condition: trigger
+            id: home
+        sequence:
+          - action: presence_simulation.stop
+            data:
+              switch_id: !input simulation_switch

--- a/custom_components/presence_simulation/config_flow.py
+++ b/custom_components/presence_simulation/config_flow.py
@@ -44,6 +44,7 @@ class PresenceSimulationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required("random", default=0): RANDOM_VALIDATOR,
             vol.Required("unavailable_as_off", default=False): bool,
             vol.Required("brightness", default=0): BRIGHTNESS_VALIDATOR,
+            vol.Optional("history_end", default=""): str,
         }
         if not info:
             return self.async_show_form(
@@ -110,6 +111,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         entities_val = self.config_entry.options.get("entities", self.config_entry.data["entities"])
         labels_val = self.config_entry.options.get("labels", self.config_entry.data.get("labels", []))
         delta_val = self.config_entry.options.get("delta", self.config_entry.data["delta"])
+        history_end_val = self.config_entry.options.get("history_end", self.config_entry.data.get("history_end", ""))
 
         data_schema = {
             vol.Required("switch", default=switch_val): str,
@@ -121,6 +123,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             vol.Required("random", default=random): RANDOM_VALIDATOR,
             vol.Required("unavailable_as_off", default=unavailable_as_off): bool,
             vol.Required("brightness", default=brightness): BRIGHTNESS_VALIDATOR,
+            vol.Optional("history_end", default=history_end_val): str,
         }
         _LOGGER.debug("switch %s", self.config_entry.data["switch"])
         _LOGGER.debug("config_entry data %s", self.config_entry.data)

--- a/custom_components/presence_simulation/config_flow.py
+++ b/custom_components/presence_simulation/config_flow.py
@@ -1,6 +1,8 @@
 from typing import Dict
 from homeassistant import config_entries
 from homeassistant.helpers.selector import (
+    DateTimeSelector,
+    DateTimeSelectorConfig,
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
@@ -44,7 +46,7 @@ class PresenceSimulationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required("random", default=0): RANDOM_VALIDATOR,
             vol.Required("unavailable_as_off", default=False): bool,
             vol.Required("brightness", default=0): BRIGHTNESS_VALIDATOR,
-            vol.Optional("history_end", default=""): str,
+            vol.Optional("history_end", default=None): DateTimeSelector(DateTimeSelectorConfig()),
         }
         if not info:
             return self.async_show_form(
@@ -111,7 +113,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         entities_val = self.config_entry.options.get("entities", self.config_entry.data["entities"])
         labels_val = self.config_entry.options.get("labels", self.config_entry.data.get("labels", []))
         delta_val = self.config_entry.options.get("delta", self.config_entry.data["delta"])
-        history_end_val = self.config_entry.options.get("history_end", self.config_entry.data.get("history_end", ""))
+        history_end_val = self.config_entry.options.get("history_end", self.config_entry.data.get("history_end"))
 
         data_schema = {
             vol.Required("switch", default=switch_val): str,
@@ -123,7 +125,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             vol.Required("random", default=random): RANDOM_VALIDATOR,
             vol.Required("unavailable_as_off", default=unavailable_as_off): bool,
             vol.Required("brightness", default=brightness): BRIGHTNESS_VALIDATOR,
-            vol.Optional("history_end", default=history_end_val): str,
+            vol.Optional("history_end", default=history_end_val or None): DateTimeSelector(DateTimeSelectorConfig()),
         }
         _LOGGER.debug("switch %s", self.config_entry.data["switch"])
         _LOGGER.debug("config_entry data %s", self.config_entry.data)

--- a/custom_components/presence_simulation/config_flow.py
+++ b/custom_components/presence_simulation/config_flow.py
@@ -46,7 +46,9 @@ class PresenceSimulationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required("random", default=0): RANDOM_VALIDATOR,
             vol.Required("unavailable_as_off", default=False): bool,
             vol.Required("brightness", default=0): BRIGHTNESS_VALIDATOR,
-            vol.Optional("history_end", default=None): DateTimeSelector(DateTimeSelectorConfig()),
+            vol.Optional("history_end", default=None): DateTimeSelector(
+                DateTimeSelectorConfig(include_date=True, include_time=True)
+            ),
         }
         if not info:
             return self.async_show_form(
@@ -125,7 +127,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             vol.Required("random", default=random): RANDOM_VALIDATOR,
             vol.Required("unavailable_as_off", default=unavailable_as_off): bool,
             vol.Required("brightness", default=brightness): BRIGHTNESS_VALIDATOR,
-            vol.Optional("history_end", default=history_end_val or None): DateTimeSelector(DateTimeSelectorConfig()),
+            vol.Optional("history_end", default=history_end_val or None): DateTimeSelector(
+                DateTimeSelectorConfig(include_date=True, include_time=True)
+            ),
         }
         _LOGGER.debug("switch %s", self.config_entry.data["switch"])
         _LOGGER.debug("config_entry data %s", self.config_entry.data)

--- a/custom_components/presence_simulation/config_flow.py
+++ b/custom_components/presence_simulation/config_flow.py
@@ -1,13 +1,16 @@
+from datetime import datetime
 from typing import Dict
 from homeassistant import config_entries
 from homeassistant.helpers.selector import (
-    DateTimeSelector,
-    DateTimeSelectorConfig,
+    DateSelector,
+    DateSelectorConfig,
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
     LabelSelector,
-    LabelSelectorConfig
+    LabelSelectorConfig,
+    TimeSelector,
+    TimeSelectorConfig,
 )
 import re
 import logging
@@ -23,6 +26,30 @@ DELTA_VALIDATOR = vol.All(vol.Coerce(int), vol.Range(min=1, max=365))
 INTERVAL_VALIDATOR = vol.All(vol.Coerce(int), vol.Range(min=5, max=3600))
 RANDOM_VALIDATOR = vol.All(vol.Coerce(int), vol.Range(min=0, max=86400))
 BRIGHTNESS_VALIDATOR = vol.All(vol.Coerce(int), vol.Range(min=0, max=100))
+
+
+def _history_end_parts(value):
+    """Return date and time defaults from a stored ISO datetime."""
+    if not value:
+        return None, None
+    try:
+        history_end = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None, None
+    return history_end.date().isoformat(), history_end.strftime("%H:%M:%S")
+
+
+def _set_history_end(info):
+    """Combine the UI date and time fields into the existing option."""
+    history_end_date = info.pop("history_end_date", None)
+    history_end_time = info.pop("history_end_time", None)
+    if bool(history_end_date) != bool(history_end_time):
+        return False
+    if history_end_date:
+        info["history_end"] = f"{history_end_date}T{history_end_time}"
+    else:
+        info.pop("history_end", None)
+    return True
 
 
 class PresenceSimulationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -46,13 +73,17 @@ class PresenceSimulationConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required("random", default=0): RANDOM_VALIDATOR,
             vol.Required("unavailable_as_off", default=False): bool,
             vol.Required("brightness", default=0): BRIGHTNESS_VALIDATOR,
-            vol.Optional("history_end", default=None): DateTimeSelector(
-                DateTimeSelectorConfig(include_date=True, include_time=True)
-            ),
+            vol.Optional("history_end_date", default=None): DateSelector(DateSelectorConfig()),
+            vol.Optional("history_end_time", default=None): TimeSelector(TimeSelectorConfig()),
         }
         if not info:
             return self.async_show_form(
                 step_id="user", data_schema=vol.Schema(data_schema)
+            )
+        if not _set_history_end(info):
+            errors["base"] = "history_end_incomplete"
+            return self.async_show_form(
+                step_id="user", data_schema=vol.Schema(data_schema), errors=errors
             )
         #if the name match with an already existing entity, ask to change it
         all_entities = self.hass.states.async_entity_ids()
@@ -116,6 +147,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         labels_val = self.config_entry.options.get("labels", self.config_entry.data.get("labels", []))
         delta_val = self.config_entry.options.get("delta", self.config_entry.data["delta"])
         history_end_val = self.config_entry.options.get("history_end", self.config_entry.data.get("history_end"))
+        history_end_date, history_end_time = _history_end_parts(history_end_val)
 
         data_schema = {
             vol.Required("switch", default=switch_val): str,
@@ -127,9 +159,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             vol.Required("random", default=random): RANDOM_VALIDATOR,
             vol.Required("unavailable_as_off", default=unavailable_as_off): bool,
             vol.Required("brightness", default=brightness): BRIGHTNESS_VALIDATOR,
-            vol.Optional("history_end", default=history_end_val or None): DateTimeSelector(
-                DateTimeSelectorConfig(include_date=True, include_time=True)
-            ),
+            vol.Optional("history_end_date", default=history_end_date): DateSelector(DateSelectorConfig()),
+            vol.Optional("history_end_time", default=history_end_time): TimeSelector(TimeSelectorConfig()),
         }
         _LOGGER.debug("switch %s", self.config_entry.data["switch"])
         _LOGGER.debug("config_entry data %s", self.config_entry.data)
@@ -144,6 +175,12 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         if info["switch"] != self.config_entry.data["switch"]:
             _LOGGER.error("Presence Simulation Switch name can't be changed")
             errors["base"] = "cannot_change_name"
+            return self.async_show_form(
+                step_id="init", data_schema=vol.Schema(data_schema), errors=errors
+            )
+
+        if not _set_history_end(info):
+            errors["base"] = "history_end_incomplete"
             return self.async_show_form(
                 step_id="init", data_schema=vol.Schema(data_schema), errors=errors
             )

--- a/custom_components/presence_simulation/history.py
+++ b/custom_components/presence_simulation/history.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 from datetime import datetime
 from homeassistant.core import HomeAssistant
 from homeassistant.components.recorder.history import get_significant_states
@@ -36,12 +36,14 @@ class HistoryManager:
         hass: HomeAssistant,
         start_time: datetime,
         entity_ids: List[str],
+        end_time: Optional[datetime] = None,
     ) -> Dict[str, List[Any]]:
         """Fetch significant states for the given entities and time range."""
-        _LOGGER.debug("Getting history from %s for %s", start_time, entity_ids)
+        _LOGGER.debug("Getting history from %s to %s for %s", start_time, end_time, entity_ids)
         history = get_significant_states(
             hass=hass,
             start_time=start_time,
+            end_time=end_time,
             entity_ids=entity_ids,
             include_start_time_state=True,
             significant_changes_only=False,

--- a/custom_components/presence_simulation/services.py
+++ b/custom_components/presence_simulation/services.py
@@ -17,6 +17,16 @@ from .entity_controller import EntityController
 _LOGGER = logging.getLogger(__name__)
 
 
+def _parse_history_end(value: Any, hass: HomeAssistant) -> Optional[datetime]:
+    """Parse a configured history cutoff as an aware UTC datetime."""
+    if not value:
+        return None
+    history_end = value if isinstance(value, datetime) else datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    if history_end.tzinfo is None:
+        history_end = pytz.timezone(hass.config.time_zone).localize(history_end)
+    return history_end.astimezone(timezone.utc)
+
+
 class PresenceSimulationServices:
     """Service handlers for presence simulation."""
 
@@ -87,6 +97,8 @@ class PresenceSimulationServices:
                     await entity.set_unavailable_as_off(call.data.get("unavailable_as_off", 0))
                 if "brightness" in call.data:
                     await entity.set_brightness(call.data.get("brightness", 0))
+                if "history_end" in call.data:
+                    await entity.set_history_end(call.data.get("history_end"))
                 if "after_ha_restart" in call.data:
                     after_ha_restart = call.data.get("after_ha_restart", False)
         else:
@@ -100,7 +112,19 @@ class PresenceSimulationServices:
             return
 
         current_date = datetime.now(timezone.utc)
-        minus_delta = current_date + timedelta(-entity.delta)
+        try:
+            history_end = _parse_history_end(entity.history_end, self._hass)
+        except (TypeError, ValueError) as err:
+            _LOGGER.error("Invalid history_end value %r: %s", entity.history_end, err)
+            return
+        if history_end is None:
+            history_start = current_date - timedelta(days=entity.delta)
+            replay_offset = timedelta(days=entity.delta)
+        else:
+            history_start = history_end - timedelta(days=entity.delta)
+            cycle_seconds = timedelta(days=entity.delta).total_seconds()
+            cycle = max(0, int((current_date - history_end).total_seconds() // cycle_seconds))
+            replay_offset = timedelta(days=entity.delta * (cycle + 1))
 
         try:
             expanded_entities = await self._expand_entities(entity.entities)
@@ -160,29 +184,33 @@ class PresenceSimulationServices:
                         e,
                     )
 
-        _LOGGER.debug("Getting the historic from %s for %s", minus_delta, expanded_entities)
+        _LOGGER.debug("Getting the historic from %s to %s for %s", history_start, history_end, expanded_entities)
 
         from homeassistant.components.recorder import get_instance
 
         get_instance(self._hass).async_add_executor_job(
             self._fetch_and_handle_history,
             self._hass,
-            minus_delta,
+            history_start,
+            history_end,
             expanded_entities,
             switch_id,
             call,
+            replay_offset,
         )
 
     def _fetch_and_handle_history(
         self,
         hass: HomeAssistant,
-        minus_delta: datetime,
+        history_start: datetime,
+        history_end: Optional[datetime],
         expanded_entities: List[str],
         switch_id: str,
         call: Optional[Any],
+        replay_offset: timedelta,
     ) -> None:
         """Fetch history and dispatch to entity simulators."""
-        history = HistoryManager.get_history(hass, minus_delta, expanded_entities)
+        history = HistoryManager.get_history(hass, history_start, expanded_entities, history_end)
         entity = self._get_switch_entity()[switch_id]
         filtered_history = HistoryManager.filter_out_undefined(
             history, not entity.unavailable_as_off
@@ -197,12 +225,12 @@ class PresenceSimulationServices:
                     switch_id,
                     entity_id,
                     filtered_history[entity_id],
-                    entity.delta,
+                    replay_offset,
                     entity.random,
                 )
             )
 
-        hass.create_task(self._schedule_restart(call, switch_id=switch_id))
+        hass.create_task(self._schedule_restart(call, switch_id=switch_id, history_end=history_end))
         _LOGGER.debug("All async tasks launched")
 
     async def _simulate_single_entity(
@@ -210,7 +238,7 @@ class PresenceSimulationServices:
         switch_id: str,
         entity_id: str,
         hist: List[Any],
-        delta: int,
+        replay_offset: timedelta,
         random_val: int,
     ) -> None:
         """Replay the historic of one entity."""
@@ -220,6 +248,7 @@ class PresenceSimulationServices:
         is_running = self._is_running
         event_fire = self._hass.bus.fire
 
+        last_past_state = None
         for idx, state in enumerate(hist):
             _LOGGER.debug("State %s", state.as_dict())
             try:
@@ -227,8 +256,8 @@ class PresenceSimulationServices:
             except AttributeError:
                 last_updated = state.last_updated
 
-            target_time = last_updated + timedelta(delta)
-            _LOGGER.debug("Switch of %s foreseen at %s", entity_id, target_time + timedelta(delta))
+            target_time = last_updated + replay_offset
+            _LOGGER.debug("Switch of %s foreseen at %s", entity_id, target_time)
 
             if idx > 0:
                 _LOGGER.debug("Randomize the event within a range of +/- %s sec", random_val)
@@ -250,6 +279,12 @@ class PresenceSimulationServices:
                         "initial_secs_left %s, target_time %s", initial_secs_left, target_time
                     )
 
+            if target_time <= datetime.now(timezone.utc):
+                last_past_state = state
+                continue
+            if last_past_state is not None:
+                await self._entity_controller.update_entity(entity_id, last_past_state, entity.unavailable_as_off, entity.brightness, False, event_fire, MY_EVENT)
+                last_past_state = None
             await entity.async_add_next_event(target_time, entity_id, state.state)
 
             while is_running(switch_id):
@@ -271,6 +306,9 @@ class PresenceSimulationServices:
                 MY_EVENT,
             )
             await entity.async_remove_event(entity_id)
+
+        if last_past_state is not None and is_running(switch_id):
+            await self._entity_controller.update_entity(entity_id, last_past_state, entity.unavailable_as_off, entity.brightness, False, event_fire, MY_EVENT)
 
     async def stop_simulation(
         self,
@@ -309,6 +347,7 @@ class PresenceSimulationServices:
             await entity.reset_labels()
             await entity.reset_delta()
             await entity.reset_random()
+            await entity.reset_history_end()
 
             scene = self._hass.states.get(
                 SCENE_PLATFORM + "." + self._get_scene_name(switch_id)
@@ -350,13 +389,18 @@ class PresenceSimulationServices:
         else:
             await self.start_simulation(call, restart=False)
 
-    async def _schedule_restart(self, call: Any, switch_id: str) -> None:
+    async def _schedule_restart(self, call: Any, switch_id: str, history_end: Optional[datetime] = None) -> None:
         """Make sure that once delta days is passed, relaunch the simulation."""
         entity = self._get_switch_entity()[switch_id]
         await entity.reset_default_values_async()
         _LOGGER.debug("Presence simulation will be relaunched in %i days", entity.delta)
 
-        start_plus_delta = datetime.now(timezone.utc) + timedelta(entity.delta)
+        if history_end is None:
+            start_plus_delta = datetime.now(timezone.utc) + timedelta(days=entity.delta)
+        else:
+            cycle_seconds = timedelta(days=entity.delta).total_seconds()
+            cycle = max(0, int((datetime.now(timezone.utc) - history_end).total_seconds() // cycle_seconds))
+            start_plus_delta = history_end + timedelta(days=entity.delta * (cycle + 1))
 
         while self._is_running(switch_id):
             secs_left = (start_plus_delta - datetime.now(timezone.utc)).total_seconds()

--- a/custom_components/presence_simulation/services.yaml
+++ b/custom_components/presence_simulation/services.yaml
@@ -27,6 +27,10 @@ start:
       name: Set light brightness
       description: Set a specific brightness fot lights that allows it
       example: 75
+    history_end:
+      name: End of source history
+      description: ISO 8601 date and time at which source history ends. The selected history is replayed cyclically from that moment.
+      example: "2026-08-09T00:00:00+02:00"
 stop:
   description: Stop the presence simulation
   name: Presence simulation stop

--- a/custom_components/presence_simulation/strings.json
+++ b/custom_components/presence_simulation/strings.json
@@ -15,7 +15,8 @@
                     "random": "Add a random time for switching entities. This parameter define the max time in seconds",
                     "unavailable_as_off": "Consider Unavailable status as Off",
 					"brightness": "Brightness to be used if light allows the feature",
-                    "history_end": "End of source history"
+                    "history_end_date": "End date of source history",
+                    "history_end_time": "End time of source history"
                 }
             }
         }
@@ -36,7 +37,8 @@
                     "random": "Add a random time for switching entities. This parameter define the max time in seconds",
                     "unavailable_as_off": "Consider Unavailable status as Off",
 					"brightness": "Brightness to be used if light allows the feature",
-                    "history_end": "End of source history"
+                    "history_end_date": "End date of source history",
+                    "history_end_time": "End time of source history"
                 }
             }
         }

--- a/custom_components/presence_simulation/strings.json
+++ b/custom_components/presence_simulation/strings.json
@@ -15,7 +15,7 @@
                     "random": "Add a random time for switching entities. This parameter define the max time in seconds",
                     "unavailable_as_off": "Consider Unavailable status as Off",
 					"brightness": "Brightness to be used if light allows the feature",
-                    "history_end": "End of source history (ISO 8601; leave empty to use now)"
+                    "history_end": "End of source history"
                 }
             }
         }
@@ -36,7 +36,7 @@
                     "random": "Add a random time for switching entities. This parameter define the max time in seconds",
                     "unavailable_as_off": "Consider Unavailable status as Off",
 					"brightness": "Brightness to be used if light allows the feature",
-                    "history_end": "End of source history (ISO 8601; leave empty to use now)"
+                    "history_end": "End of source history"
                 }
             }
         }

--- a/custom_components/presence_simulation/strings.json
+++ b/custom_components/presence_simulation/strings.json
@@ -14,7 +14,8 @@
                     "restore": "Restore state after simulation",
                     "random": "Add a random time for switching entities. This parameter define the max time in seconds",
                     "unavailable_as_off": "Consider Unavailable status as Off",
-					"brightness": "Brightness to be used if light allows the feature"
+					"brightness": "Brightness to be used if light allows the feature",
+                    "history_end": "End of source history (ISO 8601; leave empty to use now)"
                 }
             }
         }
@@ -34,7 +35,8 @@
                     "restore": "Restore state after simulation",
                     "random": "Add a random time for switching entities. This parameter define the max time in seconds",
                     "unavailable_as_off": "Consider Unavailable status as Off",
-					"brightness": "Brightness to be used if light allows the feature"
+					"brightness": "Brightness to be used if light allows the feature",
+                    "history_end": "End of source history (ISO 8601; leave empty to use now)"
                 }
             }
         }

--- a/custom_components/presence_simulation/switch.py
+++ b/custom_components/presence_simulation/switch.py
@@ -62,6 +62,7 @@ class PresenceSimulationSwitch(SwitchEntity,RestoreEntity):
         self._restore = conf["restore"]
         self._unavailable_as_off = conf.get("unavailable_as_off", False)
         self._brightness = conf.get("brightness", 0)
+        self._history_end = conf.get("history_end", "")
         self.reset_default_values()
         _LOGGER.debug("entities %s", conf["entities"])
 
@@ -145,6 +146,9 @@ class PresenceSimulationSwitch(SwitchEntity,RestoreEntity):
     @property
     def interval(self):
         return self._interval
+    @property
+    def history_end(self):
+        return self._history_end_overriden
 
     async def reset_default_values_async(self):
         self._entities_overriden = self._entities
@@ -154,6 +158,7 @@ class PresenceSimulationSwitch(SwitchEntity,RestoreEntity):
         self._delta_overriden = self._delta
         self._unavailable_as_off_overriden = self._unavailable_as_off
         self._brightness_overriden = self._brightness
+        self._history_end_overriden = self._history_end
 
     def reset_default_values(self):
         self._entities_overriden = self._entities
@@ -163,6 +168,7 @@ class PresenceSimulationSwitch(SwitchEntity,RestoreEntity):
         self._delta_overriden = self._delta
         self._unavailable_as_off_overriden = self._unavailable_as_off
         self._brightness_overriden = self._brightness
+        self._history_end_overriden = self._history_end
 
 
     #def device_state_attributes(self):
@@ -200,6 +206,8 @@ class PresenceSimulationSwitch(SwitchEntity,RestoreEntity):
                     self._unavailable_as_off_overriden = state.attributes["unavailable_as_off"]
                 if "brightness" in state.attributes:
                     self._brightness_overriden = state.attributes["brightness"]
+                if "history_end" in state.attributes:
+                    self._history_end_overriden = state.attributes["history_end"]
                 #just set internally to on, the simulation service will be called later once the HA Start event is fired
                 self.internal_turn_on()
             else:
@@ -252,6 +260,10 @@ class PresenceSimulationSwitch(SwitchEntity,RestoreEntity):
         self.attr["brightness"] = brightness
         self._brightness_overriden = brightness
 
+    async def set_history_end(self, history_end):
+        self.attr["history_end"] = history_end
+        self._history_end_overriden = history_end
+
     async def set_interval(self, interval):
         self._interval = interval
 
@@ -287,3 +299,7 @@ class PresenceSimulationSwitch(SwitchEntity,RestoreEntity):
     async def reset_brightness(self):
         if "brightness" in self.attr:
             del self.attr["brightness"]
+
+    async def reset_history_end(self):
+        if "history_end" in self.attr:
+            del self.attr["history_end"]

--- a/custom_components/presence_simulation/translations/nl.json
+++ b/custom_components/presence_simulation/translations/nl.json
@@ -15,7 +15,8 @@
                     "restore": "Herstel toestand na simulatie",
                     "random": "Add a random time for switching entities. This parameter define the max time in seconds",
                     "unavailable_as_off": "Consider Unavailable status as Off",
-                    "history_end": "Einde bronhistorie"
+                    "history_end_date": "Einddatum bronhistorie",
+                    "history_end_time": "Eindtijd bronhistorie"
                 }
             }
         }
@@ -35,7 +36,8 @@
                     "restore": "Herstel toestand na simulatie",
                     "random": "Add a random time for switching entities. This parameter define the max time in seconds",
                     "unavailable_as_off": "Consider Unavailable status as Off",
-                    "history_end": "Einde bronhistorie"
+                    "history_end_date": "Einddatum bronhistorie",
+                    "history_end_time": "Eindtijd bronhistorie"
                 }
             }
         }

--- a/custom_components/presence_simulation/translations/nl.json
+++ b/custom_components/presence_simulation/translations/nl.json
@@ -14,7 +14,8 @@
                     "interval": "Verversingsinterval (in seconden)",
                     "restore": "Herstel toestand na simulatie",
                     "random": "Add a random time for switching entities. This parameter define the max time in seconds",
-                    "unavailable_as_off": "Consider Unavailable status as Off"
+                    "unavailable_as_off": "Consider Unavailable status as Off",
+                    "history_end": "Einde bronhistorie (ISO 8601; leeg laten gebruikt nu)"
                 }
             }
         }
@@ -33,7 +34,8 @@
                     "interval": "Verversingsinterval (in seconden)",
                     "restore": "Herstel toestand na simulatie",
                     "random": "Add a random time for switching entities. This parameter define the max time in seconds",
-                    "unavailable_as_off": "Consider Unavailable status as Off"
+                    "unavailable_as_off": "Consider Unavailable status as Off",
+                    "history_end": "Einde bronhistorie (ISO 8601; leeg laten gebruikt nu)"
                 }
             }
         }

--- a/custom_components/presence_simulation/translations/nl.json
+++ b/custom_components/presence_simulation/translations/nl.json
@@ -15,7 +15,7 @@
                     "restore": "Herstel toestand na simulatie",
                     "random": "Add a random time for switching entities. This parameter define the max time in seconds",
                     "unavailable_as_off": "Consider Unavailable status as Off",
-                    "history_end": "Einde bronhistorie (ISO 8601; leeg laten gebruikt nu)"
+                    "history_end": "Einde bronhistorie"
                 }
             }
         }
@@ -35,7 +35,7 @@
                     "restore": "Herstel toestand na simulatie",
                     "random": "Add a random time for switching entities. This parameter define the max time in seconds",
                     "unavailable_as_off": "Consider Unavailable status as Off",
-                    "history_end": "Einde bronhistorie (ISO 8601; leeg laten gebruikt nu)"
+                    "history_end": "Einde bronhistorie"
                 }
             }
         }


### PR DESCRIPTION
## Summary

Adds an optional `history_end` setting to freeze the source history at a chosen date and time. The recorded window is replayed cyclically, so an extended absence does not become part of the simulated behaviour.

## Behaviour

- reads history from `history_end - delta` through `history_end`
- repeats that historical window in `delta`-day cycles
- on restart, applies only the state that should be current and schedules future transitions
- keeps existing behaviour unchanged when the field is empty

## Validation

- JSON translation files validated
- `git diff --check` passed