### PR TITLE
Add presence simulation dashboard status details

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ The service `presence_simulation.toggle` will start or stop the simulation, depe
 
 Each time the simulation calls a service (turn on a light, open a cover, ...), an event `presence_simulation_change` is fired. You can catch this event in an automation, to notify you for instance.
 
+# Dashboard example
+
+`examples/lovelace/presence_simulation_dashboard.yaml` is a native Lovelace card
+that shows the next actions, the currently active simulated entities, and the
+most recent simulation action. Replace `switch.presence_simulation` with the
+name of your own Presence Simulation switch before adding the card to a dashboard.
+
 # Buy me a coffee
 Liked some of my work? Buy me a coffee (or more likely a beer)
 

--- a/custom_components/presence_simulation/services.py
+++ b/custom_components/presence_simulation/services.py
@@ -126,6 +126,8 @@ class PresenceSimulationServices:
             _LOGGER.error("Error during identifying entities, no valid entities has been found")
             return
 
+        await entity.set_simulated_entities(expanded_entities)
+        await entity.set_history_window(minus_delta, current_date)
         entity.internal_turn_on()
         _LOGGER.debug("Presence simulation started")
 
@@ -261,7 +263,7 @@ class PresenceSimulationServices:
             if not is_running(switch_id):
                 return
 
-            await self._entity_controller.update_entity(
+            event_data = await self._entity_controller.update_entity(
                 entity_id,
                 state,
                 entity.unavailable_as_off,
@@ -270,6 +272,8 @@ class PresenceSimulationServices:
                 event_fire,
                 MY_EVENT,
             )
+            if event_data:
+                await entity.set_last_event(event_data)
             await entity.async_remove_event(entity_id)
 
     async def stop_simulation(

--- a/custom_components/presence_simulation/switch.py
+++ b/custom_components/presence_simulation/switch.py
@@ -11,6 +11,8 @@ from .const import (
 )
 SCAN_INTERVAL = timedelta(seconds=5)
 _LOGGER = logging.getLogger(__name__)
+_MAX_VISIBLE_NEXT_EVENTS = 10
+_ACTIVE_STATES = {"on", "open", "opening", "playing"}
 
 
 async def async_setup_entry(hass, config_entry, async_add_devices):
@@ -36,6 +38,7 @@ class PresenceSimulationSwitch(SwitchEntity,RestoreEntity):
         # to None by homeassistant/helpers/entity.py:ToggleEntity.
         # State will be initialized when restore_state() runs.
         self._next_events = []
+        self._simulated_entities = []
         self.id = SWITCH_PLATFORM+"."+re.sub("[^0-9a-zA-Z]", "_", config.data["switch"].lower())
         _LOGGER.debug("In init of switch - end")
 
@@ -120,6 +123,38 @@ class PresenceSimulationSwitch(SwitchEntity,RestoreEntity):
             for prop in ("next_event_datetime", "next_entity_id", "next_entity_state"):
                 if prop in self.attr:
                     del self.attr[prop]
+
+        self.attr["scheduled_event_count"] = len(self._next_events)
+        self.attr["next_events"] = [
+            {
+                "datetime": self._format_datetime(next_datetime),
+                "entity_id": entity_id,
+                "state": state,
+            }
+            for next_datetime, entity_id, state in self._next_events[
+                :_MAX_VISIBLE_NEXT_EVENTS
+            ]
+        ]
+        current_entities = []
+        active_entities = []
+        for entity_id in self._simulated_entities:
+            current_state = self.hass.states.get(entity_id)
+            if current_state is None:
+                continue
+            current = {"entity_id": entity_id, "state": current_state.state}
+            current_entities.append(current)
+            if current_state.state in _ACTIVE_STATES:
+                active_entities.append(current)
+        self.attr["current_entities"] = current_entities
+        self.attr["active_entities"] = active_entities
+        self.attr["active_entity_count"] = len(active_entities)
+
+    def _format_datetime(self, value):
+        """Format a scheduled datetime in the configured Home Assistant zone."""
+        try:
+            return value.astimezone(pytz.timezone(self.hass.config.time_zone)).isoformat()
+        except (AttributeError, TypeError, pytz.UnknownTimeZoneError):
+            return str(value)
 
     @property
     def labels(self):
@@ -214,10 +249,35 @@ class PresenceSimulationSwitch(SwitchEntity,RestoreEntity):
         self._next_events.append((next_datetime, entity_id, state))
         #sort so that the firt element is the next one
         self._next_events = sorted(self._next_events)
+        self._update_attributes()
+        self.async_write_ha_state()
 
     async def async_remove_event(self, entity_id):
         """Remove the next event of an entity"""
         self._next_events = [e for e in self._next_events if e[1] != entity_id]
+        self._update_attributes()
+        self.async_write_ha_state()
+
+    async def set_simulated_entities(self, entities):
+        """Store the resolved entities so their current state is visible."""
+        self._simulated_entities = list(entities)
+        self._update_attributes()
+        self.async_write_ha_state()
+
+    async def set_history_window(self, history_start, history_end):
+        """Expose the exact source history window used for this run."""
+        self.attr["history_start"] = self._format_datetime(history_start)
+        self.attr["source_history_end"] = self._format_datetime(history_end)
+
+    async def set_last_event(self, event_data):
+        """Expose the latest action actually sent by the simulator."""
+        self.attr["last_event"] = {
+            "datetime": self._format_datetime(datetime.now(timezone.utc)),
+            "entity_id": event_data["entity_id"],
+            "service": event_data["service"],
+        }
+        self._update_attributes()
+        self.async_write_ha_state()
 
     async def set_start_datetime(self, start_datetime):
         self.attr["simulation_start"] = start_datetime

--- a/examples/lovelace/presence_simulation_dashboard.yaml
+++ b/examples/lovelace/presence_simulation_dashboard.yaml
@@ -1,0 +1,50 @@
+type: vertical-stack
+cards:
+  - type: tile
+    entity: switch.presence_simulation
+    name: Presence simulation
+    icon: mdi:home-clock-outline
+    features:
+      - type: toggle
+
+  - type: markdown
+    title: Overzicht
+    content: >-
+      {% set sim = states.switch.presence_simulation %}
+      {% if is_state(sim.entity_id, 'on') %}
+        🟢 **Simulatie actief** · {{ state_attr(sim.entity_id, 'active_entity_count') | default(0, true) }} entiteit(en) actief
+      {% else %}
+        ⚪ **Simulatie uitgeschakeld**
+      {% endif %}
+
+      {% set next = state_attr(sim.entity_id, 'next_events') | default([], true) %}
+      {% if next %}
+        **Volgende actie**  
+        `{{ next[0].datetime | as_timestamp | timestamp_custom('%a %d %b · %H:%M', true) }}` · **{{ state_attr(next[0].entity_id, 'friendly_name') or next[0].entity_id }}** → `{{ next[0].state }}`
+      {% else %}
+        _Er is nog geen volgende actie ingepland._
+      {% endif %}
+
+  - type: markdown
+    title: Actief op dit moment
+    content: >-
+      {% set active = state_attr('switch.presence_simulation', 'active_entities') | default([], true) %}
+      {% if active %}
+        {% for item in active %}
+        - 💡 **{{ state_attr(item.entity_id, 'friendly_name') or item.entity_id }}** · `{{ item.state }}`
+        {% endfor %}
+      {% else %}
+        _Geen gevolgde entiteiten zijn nu actief._
+      {% endif %}
+
+  - type: markdown
+    title: Komende planning
+    content: >-
+      {% set events = state_attr('switch.presence_simulation', 'next_events') | default([], true) %}
+      {% if events %}
+        {% for event in events %}
+        - `{{ event.datetime | as_timestamp | timestamp_custom('%a %d %b · %H:%M', true) }}` · **{{ state_attr(event.entity_id, 'friendly_name') or event.entity_id }}** → `{{ event.state }}`
+        {% endfor %}
+      {% else %}
+        _Geen acties ingepland._
+      {% endif %}


### PR DESCRIPTION
## What changed
Adds live status attributes to the Presence Simulation switch:

- upcoming scheduled actions, capped at ten;
- currently active simulated entities;
- the most recently executed action;
- the actual source-history window for the run.

Also adds a native Lovelace example card. It only uses the documented example switch ID and requires users to replace that ID when theirs differs.

## Why
The simulator already exposed only the next action. These attributes make its schedule and current effect visible in Home Assistant without logs or custom frontend dependencies.

## Validation
- Tested locally in Home Assistant with an active simulation and a storage dashboard.
- Home Assistant configuration validation passed.
- Git diff whitespace validation passed.