### PR TITLE
Fix #308 'expected bool' error when saving options on a fresh entry

### DIFF
--- a/custom_components/presence_simulation/config_flow.py
+++ b/custom_components/presence_simulation/config_flow.py
@@ -92,7 +92,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         if "restore" in self.config_entry.options:
             restore = self.config_entry.options["restore"]
         else:
-            restore = 0
+            restore = False
         if "random" in self.config_entry.options:
             random = self.config_entry.options["random"]
         else:


### PR DESCRIPTION
When a config entry has never had a successful options save, entry.options is empty and the options flow fell back to restore = 0. That integer was used as the default for the strict `bool` schema field, so the form pre-filled 0, submitted 0, and voluptuous rejected every save with "expected bool" - blocking all configuration changes until the toggle was manually touched.

Fall back to False like the neighbouring unavailable_as_off field.

Fixes #208