### PR TITLE
Show a proper success dialog when saving options

### DIFF
--- a/custom_components/presence_simulation/config_flow.py
+++ b/custom_components/presence_simulation/config_flow.py
@@ -140,5 +140,4 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             )
 
         info["entities"] = ",".join(info["entities"])
-        self.hass.config_entries.async_update_entry(self.config_entry, options=info)
-        return self.async_abort(reason="")
+        return self.async_create_entry(title="", data=info)


### PR DESCRIPTION
The options flow saved the options manually via async_update_entry and then ended the flow with async_abort(reason=""). The frontend renders an abort by looking up the translation for the given reason; an empty reason has no translation, so every successful save popped an empty dialog with no text, which looks like something went wrong.

End the flow with async_create_entry instead - in an options flow this stores the submitted data as entry.options and fires the update listener, exactly like the manual call did, but the frontend closes the dialog with a proper success message.