### PR TITLE
# Add persistent history snapshots for Presence Simulation

### DIFF
--- a/custom_components/presence_simulation/__init__.py
+++ b/custom_components/presence_simulation/__init__.py
@@ -52,11 +52,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.services.async_register(DOMAIN, "start", services.handle_service_start)
         hass.services.async_register(DOMAIN, "stop", services.handle_service_stop)
         hass.services.async_register(DOMAIN, "toggle", services.handle_service_toggle)
+        hass.services.async_register(DOMAIN, "capture_snapshot", services.handle_service_snapshot)
+        hass.services.async_register(DOMAIN, "create_demo_snapshot", services.handle_service_demo_snapshot)
 
         async def _on_ha_started(event: Any) -> None:
             await _launch_simulation_after_restart(hass)
 
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _on_ha_started)
+
     entry.add_update_listener(update_listener)
 
     await hass.config_entries.async_forward_entry_setups(entry, [SWITCH_PLATFORM])
@@ -125,6 +128,8 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
             hass.services.async_remove(DOMAIN, "start")
             hass.services.async_remove(DOMAIN, "stop")
             hass.services.async_remove(DOMAIN, "toggle")
+            hass.services.async_remove(DOMAIN, "capture_snapshot")
+            hass.services.async_remove(DOMAIN, "create_demo_snapshot")
             _LOGGER.debug("Removed services")
 
             del hass.data[DOMAIN]

--- a/custom_components/presence_simulation/services.py
+++ b/custom_components/presence_simulation/services.py
@@ -13,6 +13,7 @@ from homeassistant.helpers import label_registry as lr, entity_registry as er
 from .const import DOMAIN, SWITCH_PLATFORM, RESTORE_SCENE, SCENE_PLATFORM, MY_EVENT, MIN_DELAY
 from .history import HistoryManager
 from .entity_controller import EntityController
+from .snapshot import SnapshotStore
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -52,6 +53,79 @@ class PresenceSimulationServices:
         import re
         return re.sub(r'_+', '_', tmp)
 
+    def _get_entity(self, call: Any) -> tuple[str, Any] | tuple[None, None]:
+        """Resolve the selected simulation switch."""
+        if call and call.data.get("switch_id"):
+            switch_id = call.data["switch_id"]
+            return switch_id, self._get_switch_entity().get(switch_id)
+        switches = self._get_switch_entity()
+        if len(switches) == 1:
+            switch_id = next(iter(switches))
+            return switch_id, switches[switch_id]
+        return None, None
+
+    async def handle_service_snapshot(self, call: Any) -> None:
+        """Capture the current recorder history into a small local snapshot."""
+        switch_id, entity = self._get_entity(call)
+        if entity is None:
+            _LOGGER.error("Select a switch_id when more than one simulator exists")
+            return
+        try:
+            history_end = _parse_history_end(call.data.get("history_end"), self._hass) or datetime.now(timezone.utc)
+            delta = int(call.data.get("delta", entity.delta))
+        except (TypeError, ValueError) as err:
+            _LOGGER.error("Invalid snapshot settings: %s", err)
+            return
+        if delta < 1:
+            _LOGGER.error("Snapshot delta must be at least one day")
+            return
+        entities = list(dict.fromkeys(await self._expand_entities(entity.entities) + await self._expand_labels(entity.labels)))
+        if not entities:
+            _LOGGER.error("Snapshot was not created: no valid entities")
+            return
+        history_start = history_end - timedelta(days=delta)
+        history = await self._hass.async_add_executor_job(
+            HistoryManager.get_history, self._hass, history_start, entities, history_end
+        )
+        history = HistoryManager.filter_out_undefined(history, not entity.unavailable_as_off)
+        snapshot = await SnapshotStore(self._hass, switch_id).save(
+            history, history_start, history_end, entities
+        )
+        await entity.set_snapshot_metadata(snapshot)
+        entity.async_write_ha_state()
+        if not snapshot["event_count"]:
+            _LOGGER.warning("Snapshot for %s contains no usable events", switch_id)
+            await self._hass.services.async_call(
+                "persistent_notification", "create",
+                {"title": "Presence Simulation", "message": "De opgeslagen historie bevat geen bruikbare gebeurtenissen."},
+                blocking=False,
+            )
+
+    async def handle_service_demo_snapshot(self, call: Any) -> None:
+        """Create a temporary seven-day evening routine for safe testing."""
+        switch_id, entity = self._get_entity(call)
+        if entity is None:
+            return
+        end = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+        start = end - timedelta(days=7)
+        schedule = (
+            ("light.lamp_hal", "on", 16, 45), ("light.ledstrip_tv", "on", 17, 30),
+            ("light.keuken_spots", "on", 19, 15), ("switch.verlichting_badkamer_l1", "on", 20, 45),
+            ("switch.verlichting_badkamer_l1", "off", 21, 0), ("light.keuken_spots", "off", 21, 30),
+            ("light.ledstrip_tv", "off", 21, 45), ("light.lamp_hal", "off", 22, 0),
+        )
+        from .snapshot import SnapshotState
+        history: dict[str, list[Any]] = {}
+        for day in range(7):
+            for entity_id, state, hour, minute in schedule:
+                moment = start + timedelta(days=day, hours=hour, minutes=minute)
+                history.setdefault(entity_id, []).append(SnapshotState(state, {}, moment))
+        snapshot = await SnapshotStore(self._hass, switch_id).save(history, start, end, list(history))
+        snapshot["synthetic"] = True
+        await SnapshotStore(self._hass, switch_id)._store.async_save(snapshot)
+        await entity.set_snapshot_metadata(snapshot)
+        entity.async_write_ha_state()
+
     async def start_simulation(
         self,
         call: Optional[Any],
@@ -78,7 +152,20 @@ class PresenceSimulationServices:
                 )
                 return
 
+            # This option must be applied even when replacing a running simulation.
+            if "use_snapshot" in call.data:
+                await entity.set_use_snapshot(call.data.get("use_snapshot", False))
+
             internal = call.data.get("internal", False) and call.data.get("internal")
+            # A normal switch turn-on is an internal service call.  When a
+            # valid local snapshot exists, prefer it automatically so users
+            # do not need to invoke the advanced `start` service manually.
+            # An explicit `use_snapshot: false` always remains authoritative.
+            if internal and "use_snapshot" not in call.data and not entity.use_snapshot:
+                available_snapshot = await SnapshotStore(self._hass, switch_id).load()
+                if available_snapshot and available_snapshot.get("event_count"):
+                    await entity.set_use_snapshot(True)
+                    await entity.set_snapshot_metadata(available_snapshot)
             if not self._is_running(switch_id) and not internal:
                 if "entity_id" in call.data:
                     if isinstance(call.data.get("entity_id"), list):
@@ -108,8 +195,15 @@ class PresenceSimulationServices:
         _LOGGER.debug("Switch id %s", switch_id)
         _LOGGER.debug("Is already running ? %s", entity.state)
         if self._is_running(switch_id):
-            _LOGGER.warning("Presence simulation already running. Doing nothing")
-            return
+            if entity.use_snapshot and call is not None:
+                # A switch turn-on can reach this point while its restored
+                # state is still "on". Replace that stale run so the snapshot
+                # is actually dispatched instead of silently returning.
+                _LOGGER.info("Replacing the running simulation with its saved snapshot")
+                await self._do_stop(switch_id, restart=True)
+            else:
+                _LOGGER.warning("Presence simulation already running. Doing nothing")
+                return
 
         current_date = datetime.now(timezone.utc)
         try:
@@ -117,7 +211,24 @@ class PresenceSimulationServices:
         except (TypeError, ValueError) as err:
             _LOGGER.error("Invalid history_end value %r: %s", entity.history_end, err)
             return
-        if history_end is None:
+        snapshot = None
+        if entity.use_snapshot:
+            snapshot = await SnapshotStore(self._hass, switch_id).load()
+            await entity.set_snapshot_metadata(snapshot)
+            if not snapshot or not snapshot.get("event_count"):
+                _LOGGER.error("No usable Presence Simulation snapshot is available")
+                await self._hass.services.async_call(
+                    "persistent_notification", "create",
+                    {"title": "Presence Simulation", "message": "Geen bruikbare opgeslagen historie. De simulatie is niet gestart."},
+                    blocking=False,
+                )
+                return
+            history_start = datetime.fromisoformat(snapshot["history_start"])
+            history_end = datetime.fromisoformat(snapshot["history_end"])
+            cycle_seconds = (history_end - history_start).total_seconds()
+            cycle = max(0, int((current_date - history_end).total_seconds() // cycle_seconds))
+            replay_offset = timedelta(seconds=cycle_seconds * (cycle + 1))
+        elif history_end is None:
             history_start = current_date - timedelta(days=entity.delta)
             replay_offset = timedelta(days=entity.delta)
         else:
@@ -151,7 +262,7 @@ class PresenceSimulationServices:
             return
 
         await entity.set_simulated_entities(expanded_entities)
-        await entity.set_history_window(minus_delta, current_date)
+        await entity.set_history_window(history_start, history_end or current_date)
         entity.internal_turn_on()
         _LOGGER.debug("Presence simulation started")
 
@@ -190,39 +301,44 @@ class PresenceSimulationServices:
 
         from homeassistant.components.recorder import get_instance
 
-        get_instance(self._hass).async_add_executor_job(
-            self._fetch_and_handle_history,
-            self._hass,
-            history_start,
-            history_end,
-            expanded_entities,
-            switch_id,
-            call,
-            replay_offset,
-        )
+        if snapshot:
+            self._dispatch_history(
+                SnapshotStore.deserialize(snapshot),
+                switch_id,
+                call,
+                replay_offset,
+                history_end,
+            )
+        else:
+            # Fetching history is blocking, but scheduling entity tasks must
+            # return to Home Assistant's event loop.  Await the executor job
+            # here instead of creating tasks from its worker thread.
+            history = await get_instance(self._hass).async_add_executor_job(
+                HistoryManager.get_history,
+                self._hass,
+                history_start,
+                expanded_entities,
+                history_end,
+            )
+            self._dispatch_history(history, switch_id, call, replay_offset, history_end)
 
-    def _fetch_and_handle_history(
+    def _dispatch_history(
         self,
-        hass: HomeAssistant,
-        history_start: datetime,
-        history_end: Optional[datetime],
-        expanded_entities: List[str],
+        history,
         switch_id: str,
         call: Optional[Any],
         replay_offset: timedelta,
+        history_end: Optional[datetime],
     ) -> None:
-        """Fetch history and dispatch to entity simulators."""
-        history = HistoryManager.get_history(hass, history_start, expanded_entities, history_end)
+        """Start replay tasks from recorder history or a persisted snapshot."""
         entity = self._get_switch_entity()[switch_id]
-        filtered_history = HistoryManager.filter_out_undefined(
-            history, not entity.unavailable_as_off
-        )
+        filtered_history = HistoryManager.filter_out_undefined(history, not entity.unavailable_as_off)
         _LOGGER.debug("history after filtering: %s", filtered_history)
 
         for entity_id in filtered_history:
             _LOGGER.debug("Entity %s", entity_id)
-            # Use create_task (thread-safe version) instead of async_create_task
-            hass.create_task(
+            # We are on Home Assistant's event loop here.
+            self._hass.async_create_task(
                 self._simulate_single_entity(
                     switch_id,
                     entity_id,
@@ -232,7 +348,9 @@ class PresenceSimulationServices:
                 )
             )
 
-        hass.create_task(self._schedule_restart(call, switch_id=switch_id, history_end=history_end))
+        self._hass.async_create_task(
+            self._schedule_restart(call, switch_id=switch_id, history_end=history_end)
+        )
         _LOGGER.debug("All async tasks launched")
 
     async def _simulate_single_entity(
@@ -285,7 +403,17 @@ class PresenceSimulationServices:
                 last_past_state = state
                 continue
             if last_past_state is not None:
-                await self._entity_controller.update_entity(entity_id, last_past_state, entity.unavailable_as_off, entity.brightness, False, event_fire, MY_EVENT)
+                event_data = await self._entity_controller.update_entity(
+                    entity_id,
+                    last_past_state,
+                    entity.unavailable_as_off,
+                    entity.brightness,
+                    False,
+                    event_fire,
+                    MY_EVENT,
+                )
+                if event_data:
+                    await entity.set_last_event(event_data)
                 last_past_state = None
             await entity.async_add_next_event(target_time, entity_id, state.state)
 
@@ -312,7 +440,17 @@ class PresenceSimulationServices:
             await entity.async_remove_event(entity_id)
 
         if last_past_state is not None and is_running(switch_id):
-            await self._entity_controller.update_entity(entity_id, last_past_state, entity.unavailable_as_off, entity.brightness, False, event_fire, MY_EVENT)
+            event_data = await self._entity_controller.update_entity(
+                entity_id,
+                last_past_state,
+                entity.unavailable_as_off,
+                entity.brightness,
+                False,
+                event_fire,
+                MY_EVENT,
+            )
+            if event_data:
+                await entity.set_last_event(event_data)
 
     async def stop_simulation(
         self,
@@ -396,7 +534,11 @@ class PresenceSimulationServices:
     async def _schedule_restart(self, call: Any, switch_id: str, history_end: Optional[datetime] = None) -> None:
         """Make sure that once delta days is passed, relaunch the simulation."""
         entity = self._get_switch_entity()[switch_id]
+        use_snapshot = entity.use_snapshot
         await entity.reset_default_values_async()
+        if use_snapshot:
+            # A snapshot must survive cycle restarts and Home Assistant restarts.
+            await entity.set_use_snapshot(True)
         _LOGGER.debug("Presence simulation will be relaunched in %i days", entity.delta)
 
         if history_end is None:
@@ -459,7 +601,11 @@ class PresenceSimulationServices:
 
     async def handle_service_start(self, call: Any) -> None:
         """Service handler for start."""
-        await self.start_simulation(call, False, None)
+        try:
+            await self.start_simulation(call, False, None)
+        except Exception:
+            _LOGGER.exception("Presence Simulation start failed")
+            raise
 
     async def handle_service_stop(self, call: Any) -> None:
         """Service handler for stop."""

--- a/custom_components/presence_simulation/services.yaml
+++ b/custom_components/presence_simulation/services.yaml
@@ -31,6 +31,30 @@ start:
       name: End of source history
       description: ISO 8601 date and time at which source history ends. The selected history is replayed cyclically from that moment.
       example: "2026-08-09T00:00:00+02:00"
+    use_snapshot:
+      name: Use saved snapshot
+      description: Replay the locally saved history snapshot instead of Recorder history.
+      example: true
+capture_snapshot:
+  name: Capture history snapshot
+  description: Save the selected history window locally for later replay without Recorder history.
+  fields:
+    switch_id:
+      name: The id of the presence simulation switch
+      example: switch.presence_simulation
+    delta:
+      name: Number of source history days
+      example: 7
+    history_end:
+      name: End of source history
+      example: "2026-08-09T00:00:00+02:00"
+create_demo_snapshot:
+  name: Create temporary demo snapshot
+  description: Creates a seven-day synthetic lighting routine for testing.
+  fields:
+    switch_id:
+      name: The id of the presence simulation switch
+      example: switch.presence_simulation
 stop:
   description: Stop the presence simulation
   name: Presence simulation stop

--- a/custom_components/presence_simulation/snapshot.py
+++ b/custom_components/presence_simulation/snapshot.py
@@ -1,0 +1,99 @@
+"""Small, persistent history snapshots for Presence Simulation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+SNAPSHOT_VERSION = 1
+
+
+@dataclass(slots=True)
+class SnapshotState:
+    """Minimal State-compatible object used while replaying a snapshot."""
+
+    state: str
+    attributes: dict[str, Any]
+    last_updated: datetime
+
+    def as_dict(self) -> dict[str, Any]:
+        """Provide the small State interface used by the replay logger."""
+        return {
+            "state": self.state,
+            "attributes": self.attributes,
+            "last_updated": self.last_updated.isoformat(),
+        }
+
+
+class SnapshotStore:
+    """Persist only the relevant state changes, not the complete recorder history."""
+
+    def __init__(self, hass: HomeAssistant, switch_id: str) -> None:
+        safe_id = switch_id.replace(".", "_")
+        self._store = Store(hass, SNAPSHOT_VERSION, f"{safe_id}_presence_snapshot")
+
+    async def load(self) -> dict[str, Any] | None:
+        data = await self._store.async_load()
+        if not isinstance(data, dict) or data.get("version") != SNAPSHOT_VERSION:
+            return None
+        return data
+
+    async def save(
+        self,
+        history: dict[str, list[Any]],
+        history_start: datetime,
+        history_end: datetime,
+        entities: list[str],
+    ) -> dict[str, Any]:
+        events: dict[str, list[dict[str, Any]]] = {}
+        for entity_id, states in history.items():
+            serialized: list[dict[str, Any]] = []
+            for state in states:
+                last_updated = getattr(state, "last_updated", None)
+                if last_updated is None:
+                    continue
+                serialized.append(
+                    {
+                        "state": state.state,
+                        "attributes": dict(state.attributes),
+                        "last_updated": last_updated.isoformat(),
+                    }
+                )
+            if serialized:
+                events[entity_id] = serialized
+
+        data = {
+            "version": SNAPSHOT_VERSION,
+            "captured_at": datetime.now(history_end.tzinfo).isoformat(),
+            "history_start": history_start.isoformat(),
+            "history_end": history_end.isoformat(),
+            "entities": entities,
+            "events": events,
+            "event_count": sum(len(items) for items in events.values()),
+        }
+        await self._store.async_save(data)
+        return data
+
+    @staticmethod
+    def deserialize(data: dict[str, Any]) -> dict[str, list[SnapshotState]]:
+        history: dict[str, list[SnapshotState]] = {}
+        for entity_id, events in data.get("events", {}).items():
+            restored: list[SnapshotState] = []
+            for event in events:
+                try:
+                    restored.append(
+                        SnapshotState(
+                            state=str(event["state"]),
+                            attributes=dict(event.get("attributes", {})),
+                            last_updated=datetime.fromisoformat(event["last_updated"]),
+                        )
+                    )
+                except (KeyError, TypeError, ValueError):
+                    continue
+            if restored:
+                history[entity_id] = restored
+        return history

--- a/custom_components/presence_simulation/switch.py
+++ b/custom_components/presence_simulation/switch.py
@@ -66,6 +66,7 @@ class PresenceSimulationSwitch(SwitchEntity,RestoreEntity):
         self._unavailable_as_off = conf.get("unavailable_as_off", False)
         self._brightness = conf.get("brightness", 0)
         self._history_end = conf.get("history_end", "")
+        self._use_snapshot = False
         self.reset_default_values()
         _LOGGER.debug("entities %s", conf["entities"])
 
@@ -89,7 +90,29 @@ class PresenceSimulationSwitch(SwitchEntity,RestoreEntity):
     async def turn_on_async(self, after_ha_restart=False, **kwargs):
         """Turn on the presence simulation"""
         _LOGGER.debug("Turn on of the presence simulation through the switch")
-        await self.hass.services.async_call(DOMAIN, "start", {"switch_id": self.id, "internal": True, "after_ha_restart": after_ha_restart})
+        await self.hass.services.async_call(
+            DOMAIN,
+            "start",
+            {
+                "switch_id": self.id,
+                "internal": True,
+                "after_ha_restart": after_ha_restart,
+            },
+            blocking=True,
+        )
+
+    async def async_turn_on(self, **kwargs):
+        """Use the event-loop-safe start route used by Home Assistant."""
+        await self.turn_on_async(**kwargs)
+
+    async def async_turn_off(self, **kwargs):
+        """Use the event-loop-safe stop route used by Home Assistant."""
+        await self.hass.services.async_call(
+            DOMAIN,
+            "stop",
+            {"switch_id": self.id, "internal": True},
+            blocking=True,
+        )
 
     def turn_on(self, **kwargs):
         """Turn on the presence simulation"""
@@ -184,6 +207,9 @@ class PresenceSimulationSwitch(SwitchEntity,RestoreEntity):
     @property
     def history_end(self):
         return self._history_end_overriden
+    @property
+    def use_snapshot(self):
+        return self._use_snapshot_overriden
 
     async def reset_default_values_async(self):
         self._entities_overriden = self._entities
@@ -194,6 +220,7 @@ class PresenceSimulationSwitch(SwitchEntity,RestoreEntity):
         self._unavailable_as_off_overriden = self._unavailable_as_off
         self._brightness_overriden = self._brightness
         self._history_end_overriden = self._history_end
+        self._use_snapshot_overriden = self._use_snapshot
 
     def reset_default_values(self):
         self._entities_overriden = self._entities
@@ -204,6 +231,7 @@ class PresenceSimulationSwitch(SwitchEntity,RestoreEntity):
         self._unavailable_as_off_overriden = self._unavailable_as_off
         self._brightness_overriden = self._brightness
         self._history_end_overriden = self._history_end
+        self._use_snapshot_overriden = self._use_snapshot
 
 
     #def device_state_attributes(self):
@@ -243,6 +271,8 @@ class PresenceSimulationSwitch(SwitchEntity,RestoreEntity):
                     self._brightness_overriden = state.attributes["brightness"]
                 if "history_end" in state.attributes:
                     self._history_end_overriden = state.attributes["history_end"]
+                if "use_snapshot" in state.attributes:
+                    self._use_snapshot_overriden = state.attributes["use_snapshot"]
                 #just set internally to on, the simulation service will be called later once the HA Start event is fired
                 self.internal_turn_on()
             else:
@@ -276,6 +306,22 @@ class PresenceSimulationSwitch(SwitchEntity,RestoreEntity):
         """Expose the exact source history window used for this run."""
         self.attr["history_start"] = self._format_datetime(history_start)
         self.attr["source_history_end"] = self._format_datetime(history_end)
+
+    async def set_use_snapshot(self, use_snapshot):
+        self.attr["use_snapshot"] = bool(use_snapshot)
+        self._use_snapshot_overriden = bool(use_snapshot)
+
+    async def set_snapshot_metadata(self, snapshot):
+        """Expose cache diagnostics without exposing its full contents."""
+        if not snapshot:
+            self.attr["snapshot_status"] = "missing"
+            return
+        self.attr["snapshot_status"] = "ready"
+        self.attr["snapshot_captured_at"] = snapshot.get("captured_at")
+        self.attr["snapshot_history_start"] = snapshot.get("history_start")
+        self.attr["snapshot_history_end"] = snapshot.get("history_end")
+        self.attr["snapshot_entity_count"] = len(snapshot.get("events", {}))
+        self.attr["snapshot_event_count"] = snapshot.get("event_count", 0)
 
     async def set_last_event(self, event_data):
         """Expose the latest action actually sent by the simulator."""


### PR DESCRIPTION
## Summary

Adds optional persistent history snapshots, allowing Presence Simulation to replay captured Recorder history even when that history is no longer available.

- Adds `capture_snapshot` and `create_demo_snapshot` services.
- Adds optional snapshot replay with persisted snapshot metadata.
- Preserves snapshot mode across simulation-cycle restarts.
- Keeps the existing fixed source-history-window and dashboard-status improvements intact.
